### PR TITLE
Fix cut find bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+**Version 1.3.1**
+=================
+- Fix bug in `find_cuts()` where on circuits that already had the desired partition early return condition would return incorrect type.
+
 **Version 1.3.0**
 =================
 

--- a/QCut/QCutFind/cut_finding.py
+++ b/QCut/QCutFind/cut_finding.py
@@ -204,16 +204,15 @@ def find_cuts(  # noqa: C901
     )
 
     components = rx.connected_components(graph)
-    labels = {}
     if len(components) == num_partitions:
+        labels = {}
         for comp_ind, comp in enumerate(components):
             for node in comp:
                 labels[node] = comp_ind
-        return circuit, [], [], labels, graph, nodes_on_qubit
-
-    labels = k_way_metis_partition(graph, num_partitions)
-
-    cut_data, cut_data_test = extract_cuts(graph, labels)
+        cut_data, cut_data_test = [], []
+    else:
+        labels = k_way_metis_partition(graph, num_partitions)
+        cut_data, cut_data_test = extract_cuts(graph, labels)
 
     if max_qubits is not None:
         cut_data, cut_data_test, labels = refine_cuts(

--- a/tests/test_automatic_cuts.py
+++ b/tests/test_automatic_cuts.py
@@ -27,6 +27,7 @@ circuit2.cx(1, 2)
 
 circuit2.cx(2, 3)
 
+
 def test_find_cuts() -> None:
     """Test find_cuts function.
 
@@ -38,6 +39,7 @@ def test_find_cuts() -> None:
         cut_circuit = find_cuts(circ.copy(), sq.cut_sizes[solution_index], cuts="both")
 
         assert len(cut_circuit.subcircuits) == sq.cut_sizes[solution_index]
+
 
 def test_find_gate_cuts():
     """Test find_cuts function on a circuit with a cut gate.
@@ -57,6 +59,7 @@ def test_find_gate_cuts():
         for op in circ.data:
             assert "meas" not in op.operation.name.lower()
             assert "init" not in op.operation.name.lower()
+
 
 def test_auto_refine_wire():
     """Test find_cuts function on a circuit with a cut gate.

--- a/tests/test_new_gate_cuts.py
+++ b/tests/test_new_gate_cuts.py
@@ -37,6 +37,7 @@ def test_cutISWAP_can_be_appended():
     qc.append(ck.cutISWAP(), [0, 1])
     assert any("CutISWAP" in op.operation.name for op in qc.data)
 
+
 def _make_cut_location(gate_name=None):
     from qiskit import QuantumRegister
 
@@ -73,6 +74,7 @@ def test_cut_location_str_includes_gate_name():
     loc = _make_cut_location(gate_name="iswap")
     assert "iswap" in str(loc)
 
+
 def test_qpd_registry_contains_expected_gates():
     assert "cz" in QPD_REGISTRY
     assert "swap" in QPD_REGISTRY
@@ -95,6 +97,7 @@ def test_qpd_registry_swap_length():
 
 def test_qpd_registry_iswap_length():
     assert len(QPD_REGISTRY["iswap"]) == len(iswap_qpd)
+
 
 def test_get_qpd_combinations_unknown_gate_raises():
     loc = _make_cut_location(gate_name="unknown_gate")
@@ -135,6 +138,7 @@ def test_get_qpd_combinations_mixed_cuts():
     gate_loc = _make_cut_location(gate_name="cz")
     combos = list(get_qpd_combinations([wire_loc, gate_loc]))
     assert len(combos) == len(identity_qpd) * len(cz_qpd)
+
 
 def test_get_weights_sum_equals_num_groups():
     coefficients = [1 / 2, 1 / 2, -1 / 2, 1 / 2]
@@ -200,6 +204,7 @@ def test_iswap_cut_expectation_values():
     expvs = ck.estimate_expectation_values(results, cut_exp.expv_data())
     for computed, expected in zip(expvs, _iswap_expected):
         assert abs(computed - expected) < 0.15
+
 
 def test_find_cuts_basis_includes_swap_and_iswap():
     from QCut.QCutFind.cut_finding import BASIS_GATES


### PR DESCRIPTION
## Description

- Fix bug in `find_cuts()` where on circuits that already had the desired partition early return condition would return incorrect type.

---

## Type of Change

Please check the type(s) of changes made in this PR:

- [x] Bug Fix (non-breaking change that fixes an issue)
- [ ] New Feature (non-breaking change that adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (adds or updates documentation)
- [ ] Refactor (code restructuring without changing external behaviour)
- [ ] Other (please specify):  

- For non-breaking changes remember to run `tox`to test against older qiskit versions.

---

## Checklist

Please check all relevant boxes to ensure your pull request is ready for review:

- [x] I have tested my changes locally and they work as expected.
    * For changes that should be backwards compatible to older Qiskit versions run `tox` in addition to pytest tests ran by CI
- [x] I have added/updated relevant documentation (if applicable).
- [x] I have formatted my code using the project’s coding style or linter.
- [x] I have added tests that prove my fix is effective or my feature works (if applicable).
- [x] All new and existing tests pass.
- [x] My code follows the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.

---
