### PR TITLE
Fix autocut weights

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+**Version 1.3.2**
+=================
+- Fix bug in how weights for different gates were being handled by `QCutFind`.
+
 **Version 1.3.1**
 =================
 - Fix bug in `find_cuts()` where on circuits that already had the desired partition early return condition would return incorrect type.

--- a/QCut/QCutFind/cut_finding.py
+++ b/QCut/QCutFind/cut_finding.py
@@ -200,7 +200,7 @@ def find_cuts(  # noqa: C901
     circuit = transpile(circuit, optimization_level=0, basis_gates=BASIS_GATES)
 
     graph, nodes_on_qubit = circ_to_graph(
-        circuit, gateCutWeight=gate_cut_weight, wireCutWeight=wire_cut_weight
+        circuit, mode=cuts
     )
 
     components = rx.connected_components(graph)

--- a/QCut/QCutFind/cut_finding.py
+++ b/QCut/QCutFind/cut_finding.py
@@ -192,16 +192,11 @@ def find_cuts(  # noqa: C901
     if num_partitions == 1:
         return circuit, [], []
 
-    gate_cut_weight = 3 if (cuts == "both" or cuts == "gate") else 100000000000
-    wire_cut_weight = 4 if (cuts == "both" or cuts == "wire") else 100000000000
-
     circuit.remove_final_measurements()
 
     circuit = transpile(circuit, optimization_level=0, basis_gates=BASIS_GATES)
 
-    graph, nodes_on_qubit = circ_to_graph(
-        circuit, mode=cuts
-    )
+    graph, nodes_on_qubit = circ_to_graph(circuit, mode=cuts)
 
     components = rx.connected_components(graph)
     if len(components) == num_partitions:

--- a/QCut/QCutFind/graph_circuit_utils.py
+++ b/QCut/QCutFind/graph_circuit_utils.py
@@ -4,7 +4,7 @@ vice versa, as well as functions for updating node and edge information in the g
 """
 
 import rustworkx as rx
-
+from QCut.qpd_operations import QPD_REGISTRY
 
 def weight_fn(edge_data):
     """
@@ -81,8 +81,36 @@ def update_nodes_on_qubit(nodes_on_qubit, qubit, node):
     else:
         nodes_on_qubit[qubit].append(node)
 
+def get_gate_weight(gate_name, mode="gate"):
+    """
+    Get the weight of a gate based on its name and the specified mode (gate or wire or both).
+    Args:
+        gate_name: The name of the gate.
+        mode: The mode for calculating weight ("gate", "wire", or "both").
+    Returns:
+        The weight of the gate.
+    """ 
+    if mode == "wire":
+        return 100000000000
+    if gate_name not in QPD_REGISTRY:
+        raise ValueError(f"Gate {gate_name} not found in QPD_REGISTRY.")
+    else:
+        qpd = QPD_REGISTRY[gate_name]
+        return int(sum([(abs(x["c"])) for x in qpd]))
+    
+def get_wire_weight(mode="wire"):
+    """
+    Get the weight of a wire based on the specified mode (gate or wire or both).
+    Args:
+        mode: The mode for calculating weight ("gate", "wire", or "both").
+    Returns:
+        The weight of the wire.
+    """ 
+    if mode == "gate":
+        return 100000000000
+    return 4
 
-def circ_to_graph(circuit, gateCutWeight=3, wireCutWeight=4):  # noqa: C901
+def circ_to_graph(circuit, mode="both"):  # noqa: C901
     """
     Convert a quantum circuit to a graph representation.
 
@@ -146,7 +174,7 @@ def circ_to_graph(circuit, gateCutWeight=3, wireCutWeight=4):  # noqa: C901
             G.add_edge(
                 added[-2],
                 added[-1],
-                (op[0], op[1][0], op[1][2], gateCutWeight),
+                (op[0], op[1][0], op[1][2], get_gate_weight(op[1][0], mode)),
             )
         elif op[1][2][1] not in track_nodes.keys():
             update_added(added_set, added, op)
@@ -165,15 +193,15 @@ def circ_to_graph(circuit, gateCutWeight=3, wireCutWeight=4):  # noqa: C901
             G.add_edge(
                 added[-2],
                 added[-1],
-                (op[0], op[1][0], op[1][2], gateCutWeight),
+                (op[0], op[1][0], op[1][2], get_gate_weight(op[1][0], mode)),
             )
             if ind == []:
-                G.add_edge(op[1][2][0], added[-1], (op[1][2][0], wireCutWeight))
+                G.add_edge(op[1][2][0], added[-1], (op[1][2][0], get_wire_weight(mode)))
             else:
                 if len(ind) == 1:
-                    G.add_edge(ind[-1], op[1][2][0], (op[1][2][0], wireCutWeight))
+                    G.add_edge(ind[-1], op[1][2][0], (op[1][2][0], get_wire_weight(mode)))
                 else:
-                    G.add_edge(ind[-1], ind[-2], (op[1][2][0], wireCutWeight))
+                    G.add_edge(ind[-1], ind[-2], (op[1][2][0], get_wire_weight(mode)))
         elif op[1][2][0] not in track_nodes.keys():
             update_added(added_set, added, op)
 
@@ -191,15 +219,15 @@ def circ_to_graph(circuit, gateCutWeight=3, wireCutWeight=4):  # noqa: C901
             G.add_edge(
                 added[-2],
                 added[-1],
-                (op[0], op[1][0], op[1][2], gateCutWeight),
+                (op[0], op[1][0], op[1][2], get_gate_weight(op[1][0], mode)),
             )
             if ind == []:
-                G.add_edge(op[1][2][1], added[-1], (op[1][2][1], wireCutWeight))
+                G.add_edge(op[1][2][1], added[-1], (op[1][2][1], get_wire_weight(mode)))
             else:
                 if len(ind) == 1:
-                    G.add_edge(ind[-1], op[1][2][1], (op[1][2][1], wireCutWeight))
+                    G.add_edge(ind[-1], op[1][2][1], (op[1][2][1], get_wire_weight(mode)))
                 else:
-                    G.add_edge(ind[-1], ind[-2], (op[1][2][1], wireCutWeight))
+                    G.add_edge(ind[-1], ind[-2], (op[1][2][1], get_wire_weight(mode)))
         else:
             update_added(added_set, added, op)
             track_nodes[op[1][2][0]].append(added[-2])
@@ -213,22 +241,22 @@ def circ_to_graph(circuit, gateCutWeight=3, wireCutWeight=4):  # noqa: C901
             G.add_edge(
                 added[-2],
                 added[-1],
-                (op[0], op[1][0], op[1][2], gateCutWeight),
+                (op[0], op[1][0], op[1][2], get_gate_weight(op[1][0], mode)),
             )
             if ind0 == []:
-                G.add_edge(op[1][2][0], added[-1], (op[1][2][0], wireCutWeight))
+                G.add_edge(op[1][2][0], added[-1], (op[1][2][0], get_wire_weight(mode)))
             else:
                 if len(ind0) == 1:
-                    G.add_edge(ind0[-1], op[1][2][0], (op[1][2][0], wireCutWeight))
+                    G.add_edge(ind0[-1], op[1][2][0], (op[1][2][0], get_wire_weight(mode)))
                 else:
-                    G.add_edge(ind0[-1], ind0[-2], (op[1][2][0], wireCutWeight))
+                    G.add_edge(ind0[-1], ind0[-2], (op[1][2][0], get_wire_weight(mode)))
             if ind1 == []:
-                G.add_edge(op[1][2][1], added[-2], (op[1][2][1], wireCutWeight))
+                G.add_edge(op[1][2][1], added[-2], (op[1][2][1], get_wire_weight(mode)))
             else:
                 if len(ind1) == 1:
-                    G.add_edge(ind1[-1], op[1][2][1], (op[1][2][1], wireCutWeight))
+                    G.add_edge(ind1[-1], op[1][2][1], (op[1][2][1], get_wire_weight(mode)))
                 else:
-                    G.add_edge(ind1[-1], ind1[-2], (op[1][2][1], wireCutWeight))
+                    G.add_edge(ind1[-1], ind1[-2], (op[1][2][1], get_wire_weight(mode)))
 
     # Remove nodes with degree 0 (not connected to anything)
     isolated_nodes = [node for node in G.node_indices() if G.degree(node) == 0]

--- a/QCut/QCutFind/graph_circuit_utils.py
+++ b/QCut/QCutFind/graph_circuit_utils.py
@@ -4,7 +4,9 @@ vice versa, as well as functions for updating node and edge information in the g
 """
 
 import rustworkx as rx
+
 from QCut.qpd_operations import QPD_REGISTRY
+
 
 def weight_fn(edge_data):
     """
@@ -81,15 +83,17 @@ def update_nodes_on_qubit(nodes_on_qubit, qubit, node):
     else:
         nodes_on_qubit[qubit].append(node)
 
+
 def get_gate_weight(gate_name, mode="gate"):
     """
-    Get the weight of a gate based on its name and the specified mode (gate or wire or both).
+    Get the weight of a gate based on its name and the specified mode
+    (gate or wire or both).
     Args:
         gate_name: The name of the gate.
         mode: The mode for calculating weight ("gate", "wire", or "both").
     Returns:
         The weight of the gate.
-    """ 
+    """
     if mode == "wire":
         return 100000000000
     if gate_name not in QPD_REGISTRY:
@@ -97,7 +101,8 @@ def get_gate_weight(gate_name, mode="gate"):
     else:
         qpd = QPD_REGISTRY[gate_name]
         return int(sum([(abs(x["c"])) for x in qpd]))
-    
+
+
 def get_wire_weight(mode="wire"):
     """
     Get the weight of a wire based on the specified mode (gate or wire or both).
@@ -105,10 +110,11 @@ def get_wire_weight(mode="wire"):
         mode: The mode for calculating weight ("gate", "wire", or "both").
     Returns:
         The weight of the wire.
-    """ 
+    """
     if mode == "gate":
         return 100000000000
     return 4
+
 
 def circ_to_graph(circuit, mode="both"):  # noqa: C901
     """
@@ -199,7 +205,9 @@ def circ_to_graph(circuit, mode="both"):  # noqa: C901
                 G.add_edge(op[1][2][0], added[-1], (op[1][2][0], get_wire_weight(mode)))
             else:
                 if len(ind) == 1:
-                    G.add_edge(ind[-1], op[1][2][0], (op[1][2][0], get_wire_weight(mode)))
+                    G.add_edge(
+                        ind[-1], op[1][2][0], (op[1][2][0], get_wire_weight(mode))
+                    )
                 else:
                     G.add_edge(ind[-1], ind[-2], (op[1][2][0], get_wire_weight(mode)))
         elif op[1][2][0] not in track_nodes.keys():
@@ -225,7 +233,9 @@ def circ_to_graph(circuit, mode="both"):  # noqa: C901
                 G.add_edge(op[1][2][1], added[-1], (op[1][2][1], get_wire_weight(mode)))
             else:
                 if len(ind) == 1:
-                    G.add_edge(ind[-1], op[1][2][1], (op[1][2][1], get_wire_weight(mode)))
+                    G.add_edge(
+                        ind[-1], op[1][2][1], (op[1][2][1], get_wire_weight(mode))
+                    )
                 else:
                     G.add_edge(ind[-1], ind[-2], (op[1][2][1], get_wire_weight(mode)))
         else:
@@ -247,14 +257,18 @@ def circ_to_graph(circuit, mode="both"):  # noqa: C901
                 G.add_edge(op[1][2][0], added[-1], (op[1][2][0], get_wire_weight(mode)))
             else:
                 if len(ind0) == 1:
-                    G.add_edge(ind0[-1], op[1][2][0], (op[1][2][0], get_wire_weight(mode)))
+                    G.add_edge(
+                        ind0[-1], op[1][2][0], (op[1][2][0], get_wire_weight(mode))
+                    )
                 else:
                     G.add_edge(ind0[-1], ind0[-2], (op[1][2][0], get_wire_weight(mode)))
             if ind1 == []:
                 G.add_edge(op[1][2][1], added[-2], (op[1][2][1], get_wire_weight(mode)))
             else:
                 if len(ind1) == 1:
-                    G.add_edge(ind1[-1], op[1][2][1], (op[1][2][1], get_wire_weight(mode)))
+                    G.add_edge(
+                        ind1[-1], op[1][2][1], (op[1][2][1], get_wire_weight(mode))
+                    )
                 else:
                     G.add_edge(ind1[-1], ind1[-2], (op[1][2][1], get_wire_weight(mode)))
 


### PR DESCRIPTION
## Description

**Version 1.3.2**
=================
- Fix bug in how weights for different gates were being handled by `QCutFind`.

---

## Type of Change

Please check the type(s) of changes made in this PR:

- [x] Bug Fix (non-breaking change that fixes an issue)
- [ ] New Feature (non-breaking change that adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (adds or updates documentation)
- [x] Refactor (code restructuring without changing external behaviour)
- [ ] Other (please specify):  

- For non-breaking changes remember to run `tox`to test against older qiskit versions.

---

## Checklist

Please check all relevant boxes to ensure your pull request is ready for review:

- [x] I have tested my changes locally and they work as expected.
    * For changes that should be backwards compatible to older Qiskit versions run `tox` in addition to pytest tests ran by CI
- [x] I have added/updated relevant documentation (if applicable).
- [x] I have formatted my code using the project’s coding style or linter.
- [x] I have added tests that prove my fix is effective or my feature works (if applicable).
- [x] All new and existing tests pass.
- [x] My code follows the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.

---
